### PR TITLE
Merge dev into main

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -97,7 +97,5 @@ jobs:
         envs: DIRECTORY
         script: |
           cd ~/$DIRECTORY
-          cp ./nginx/nginx.conf /etc/nginx/nginx.conf
-          cp ./redis/redis.conf /usr/local/etc/redis/redis.conf
           docker compose pull
           docker compose up -d

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,103 @@
+name: CI/CD Workflow
+
+on: 
+  push:
+  # Run by default on all the branches. Deploy job will run on main only, due to condition
+  # This enables creating tagged docker images in GHCR for each branch without deploying them
+  # To change this behavior and builkd for main only, replace the asterisks with main
+    branches:
+      - '**'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
+      REF_NAME: ${{ github.ref_name }}
+      RUN_NUMBER: ${{ github.run_number }}
+    
+    steps:
+    - name: 🤝 Checkout Code
+      uses: actions/checkout@v4
+      
+    - name: 🐳 Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: 🔑 Login to GitHub Container Registry
+      uses: docker/login-action@v1 
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        
+    #For DockerHub (set proper env values above)
+    #- name: Login to DockerHub
+    #  uses: docker/login-action@v1 
+    #  with:
+    #    username: ${{ secrets.DOCKER_USERNAME }}
+    #    password: ${{ secrets.DOCKER_TOKEN }}
+
+    - name: 🚢 Build and push tagged only
+      id: docker_build
+      if: github.ref != 'refs/heads/main' # This step runs on non-main branches
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: ${{ env.IMAGE_NAME }}:${{ env.REF_NAME }}-${{ env.RUN_NUMBER }}
+        
+    - name: 🎁 Build and push tagged and latest
+      id: docker_build_latest
+      if: github.ref == 'refs/heads/main' # This step runs on main branch only
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: |
+          ${{ env.IMAGE_NAME }}:${{ env.REF_NAME }}-${{ env.RUN_NUMBER }}
+          ${{ env.IMAGE_NAME }}:latest
+
+  deploy:
+    needs: build-and-push
+    if: github.ref == 'refs/heads/main' # This condition ensures that deploy job runs only for main branch
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: 🤝 Checkout Code
+      uses: actions/checkout@v4
+      with:
+        ref: main # Checkout only relevant branch
+
+    # Remove unnecessary git and github folders before copying files to VM
+    - name: 🚮 Remove git and github folders
+      run: |
+        rm -rf .git .github 
+
+    - name: 📤 Copy files to VM
+      uses: appleboy/scp-action@v0.1.4
+      with:
+        host: ${{ secrets.REMOTE_HOST }}
+        username: ${{ secrets.REMOTE_USER }}
+        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        source: "." # Copy all the files to the VM
+        target: ${{github.event.repository.name}}
+        overwrite: true
+
+    - name: 🚀 Deploy to AWS VM
+      uses: appleboy/ssh-action@v1.0.0
+      env:
+        DIRECTORY: ${{github.event.repository.name}}
+      with:
+        host: ${{ secrets.REMOTE_HOST }}
+        username: ${{ secrets.REMOTE_USER }}
+        key: ${{ secrets.SSH_PRIVATE_KEY }}
+        envs: DIRECTORY
+        script: |
+          cd ~/$DIRECTORY
+          cp ./nginx/nginx.conf /etc/nginx/nginx.conf
+          cp ./redis/redis.conf /usr/local/etc/redis/redis.conf
+          docker compose pull
+          docker compose up -d

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Use the Python 3.11-slim base image from Docker Hub
+FROM python:3.11-slim
+
+# Set the working directory within the container to /app
+WORKDIR /app
+
+# Copy the local requirements.txt file to the /app directory in the container
+COPY requirements.txt requirements.txt
+
+# Install the Python dependencies listed in requirements.txt
+RUN pip install -r requirements.txt
+
+# Copy the contents of the local application code into the /app directory in the container
+COPY . .
+
+# Run Gunicorn to serve the "counter_service:app" application on 0.0.0.0:8080
+# to make it accessible outside the container, e.g. for Nginx.
+CMD ["gunicorn", "-b", "0.0.0.0:8080", "counter_service:app"]

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ This repository contains the source code and configuration files for a Counter S
 
 ## Repository Structure
 ```
-├────── .github - Github actions folder
-├────── nginx - Nginx configuration folder
-├────── redis - Redis configuration folder
+├────── .github/ - Github actions folder
+├────── nginx/ - Nginx configuration folder
+├────── redis/ - Redis configuration folder
 ├── Dockerfile - Dockerfile for counter-service
 ├── counter_service.py - Main counter-service functionality
 ├── requirements.txt - counter-service dependencies, restored at build time
@@ -86,6 +86,6 @@ If you need to revert to a previous version of the service due to any issue with
 
 5. Navigate to the directory containing the docker-compose.yml file and run:
    ```yaml
-   docker-compose up -d
+   docker compose up -d
    ```
    This command will stop the running service and start it again with the specified image version, thus rolling back to the older, desired version of the service.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,90 @@
 # counter-service
 Counts POST requests, returns count on GET request.
+
+## Overview
+This repository contains the source code and configuration files for a Counter Service. The service consists of three components: a custom Counter Service, Redis, and Nginx.
+
+- **Counter Service**: Counts ```POST``` requests sent to the service, displays the count on ```GET``` requests.
+- **Redis**: Utilized as an in-memory data store, persisted on a name mount in the host.
+- **Nginx**: Serves as a reverse proxy to handle requests and forward them to the Counter Service.
+
+## Repository Structure
+```
+├── counter-service # Counter Service source code, requirements and Dockerfile
+├────── .github # Github actions folder
+├────── nginx # Nginx configuration file
+├────── redis # Redis configuration file
+├── Dockerfile # Dockerfile for counter-service
+├── counter_service.py # Main counter-service functionality
+├── requirements.txt # counter-service dependencies, restored at build time
+└── docker-compose.yml # Docker Compose file to orchestrate the services
+```
+
+## Prerequisites
+- Docker
+- Docker Compose
+
+## CI/CD
+GitHub Actions takes care on deployment to pre-defined remote host.
+
+Remote host address, username and SSH key are defined as GitHub Actions Secrets for the repository.
+
+Each push to ```main``` branch will automatically trigger GitHub Actions pipeline, that:
+1. Clones the repository
+1. Builds the counter-service docker image based on Dockerfile
+1. Pushes the created Docker image to GitHub Container Registry, tagged with the branch name and GitHub Actions run number, in addition to a ```latest``` tag.
+1. Copies the relevant files to the destination VM
+1. Sets Nginx and Redis configuration files in defined bind mounts on the destination VM
+1. Pulls and starts all the services, using ```docker compose```.
+
+Each push to non-```main``` branch will automatically trigger GitHub Actions pipeline, that:
+1. Clones the repository
+1. Builds the counter-service docker image based on Dockerfile
+1. Pushes the created Docker image to GitHub Container Registry, tagged with the branch name and GitHub Actions run number.
+- No deployment is performed for non-main brnahces.
+
+## Manual Installation
+
+To deploy the service manually, follow the steps below:
+
+**1. Clone the Repository:**
+   ```sh
+   git clone [Repository URL]
+   cd [Repository Name]
+   ```
+
+**2. Copy configuration files:**
+
+Within the application directory, copy configuration files to defined bind mounts:
+```
+cp ./nginx/nginx.conf /etc/nginx/nginx.conf
+cp ./redis/redis.conf /usr/local/etc/redis/redis.conf
+```
+
+**3. Pull latest image and start services** 
+```
+docker compose pull
+docker compose up -d
+```
+
+## Rollback
+
+If you need to revert to a previous version of the service due to any issue with the latest version, you can do so by modifying the `docker-compose.yml` file on the host machine.
+
+### Steps
+1. Open `docker-compose.yml` in a text editor.
+
+2. Locate the `image` attribute under the `counter-service` service definition.
+
+3. Replace the `latest` tag or the existing tag with the tag of the desired version:
+
+   ```yaml
+   image: ghcr.io/mmayzlesh/counter-service:<desired version>
+   ```
+4. Save the file and exit the text editor.
+
+5. Navigate to the directory containing the docker-compose.yml file and run:
+   ```yaml
+   docker-compose up -d
+   ```
+   This command will stop the running service and start it again with the specified image version, thus rolling back to the older, desired version of the service.

--- a/README.md
+++ b/README.md
@@ -4,20 +4,19 @@ Counts POST requests, returns count on GET request.
 ## Overview
 This repository contains the source code and configuration files for a Counter Service. The service consists of three components: a custom Counter Service, Redis, and Nginx.
 
-- **Counter Service**: Counts ```POST``` requests sent to the service, displays the count on ```GET``` requests.
-- **Redis**: Utilized as an in-memory data store, persisted on a name mount in the host.
+- **Counter Service**: A Python service that counts ```POST``` requests sent to the service and displays the count on ```GET``` requests.
+- **Redis**: Utilized as an in-memory data store, persisted on a named mount on the host.
 - **Nginx**: Serves as a reverse proxy to handle requests and forward them to the Counter Service.
 
 ## Repository Structure
 ```
-├── counter-service # Counter Service source code, requirements and Dockerfile
-├────── .github # Github actions folder
-├────── nginx # Nginx configuration file
-├────── redis # Redis configuration file
-├── Dockerfile # Dockerfile for counter-service
-├── counter_service.py # Main counter-service functionality
-├── requirements.txt # counter-service dependencies, restored at build time
-└── docker-compose.yml # Docker Compose file to orchestrate the services
+├────── .github - Github actions folder
+├────── nginx - Nginx configuration folder
+├────── redis - Redis configuration folder
+├── Dockerfile - Dockerfile for counter-service
+├── counter_service.py - Main counter-service functionality
+├── requirements.txt - counter-service dependencies, restored at build time
+└── docker-compose.yml - Docker Compose file to orchestrate the services
 ```
 
 ## Prerequisites
@@ -25,22 +24,24 @@ This repository contains the source code and configuration files for a Counter S
 - Docker Compose
 
 ## CI/CD
-GitHub Actions takes care on deployment to pre-defined remote host.
+GitHub Actions take care of the CI/CD process, which ultimately deploys to a remote host.
 
-Remote host address, username and SSH key are defined as GitHub Actions Secrets for the repository.
+The remote host's address, username, and SSH key are defined as GitHub Actions Secrets for the repository.
 
-Each push to ```main``` branch will automatically trigger GitHub Actions pipeline, that:
-1. Clones the repository
-1. Builds the counter-service docker image based on Dockerfile
-1. Pushes the created Docker image to GitHub Container Registry, tagged with the branch name and GitHub Actions run number, in addition to a ```latest``` tag.
-1. Copies the relevant files to the destination VM
-1. Sets Nginx and Redis configuration files in defined bind mounts on the destination VM
-1. Pulls and starts all the services, using ```docker compose```.
+Each push to the ```main``` branch will automatically trigger a GitHub Actions pipeline, which does the following:
 
-Each push to non-```main``` branch will automatically trigger GitHub Actions pipeline, that:
-1. Clones the repository
-1. Builds the counter-service docker image based on Dockerfile
-1. Pushes the created Docker image to GitHub Container Registry, tagged with the branch name and GitHub Actions run number.
+1. Clones the repository.
+2. Builds the counter-service Docker image based on the Dockerfile.
+3. Pushes the created Docker image to the GitHub Container Registry, tagged with the branch name and GitHub Actions run number, in addition to a latest tag.
+4. Copies the relevant files to the destination VM.
+5. Sets Nginx and Redis configuration files in defined bind mounts on the destination VM.
+6. Pulls and starts all the services using docker-compose.
+
+Each push to a non-```main``` branch will automatically trigger a GitHub Actions pipeline, which does the following:
+
+1. Clones the repository.
+2. Builds the counter-service Docker image based on the Dockerfile.
+3. Pushes the created Docker image to the GitHub Container Registry, tagged with the branch name and GitHub Actions run number.
 - No deployment is performed for non-main brnahces.
 
 ## Manual Installation

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ Each push to the ```main``` branch will automatically trigger a GitHub Actions p
 2. Builds the counter-service Docker image based on the Dockerfile.
 3. Pushes the created Docker image to the GitHub Container Registry, tagged with the branch name and GitHub Actions run number, in addition to a latest tag.
 4. Copies the relevant files to the destination VM.
-5. Sets Nginx and Redis configuration files in defined bind mounts on the destination VM.
-6. Pulls and starts all the services using docker-compose.
+5. Pulls and starts all the services using docker-compose.
 
 Each push to a non-```main``` branch will automatically trigger a GitHub Actions pipeline, which does the following:
 
@@ -54,15 +53,7 @@ To deploy the service manually, follow the steps below:
    cd [Repository Name]
    ```
 
-**2. Copy configuration files:**
-
-Within the application directory, copy configuration files to defined bind mounts:
-```
-cp ./nginx/nginx.conf /etc/nginx/nginx.conf
-cp ./redis/redis.conf /usr/local/etc/redis/redis.conf
-```
-
-**3. Pull latest image and start services** 
+**2. Pull latest image and start services** 
 ```
 docker compose pull
 docker compose up -d

--- a/counter_service.py
+++ b/counter_service.py
@@ -1,0 +1,36 @@
+# Import necessary modules from Flask, Redis, and the OS
+from flask import Flask, request
+import redis
+import os
+
+# Create a Flask web application instance
+app = Flask(__name__)
+
+# Connect to the Redis server using the 'redis' hostname and default port (6379)
+# Set decode_responses=True to ensure that Redis responses are decoded to strings
+r = redis.Redis(host='redis', port=6379, decode_responses=True)
+
+# Define a route for the root URL ('/') that handles both GET and POST requests
+@app.route('/', methods=['GET', 'POST'])
+def counter():
+    if request.method == 'POST':
+        # If it's a POST request, increment the 'count' key in Redis
+        r.incr('count')
+    
+    # Retrieve the current value of the 'count' key from Redis
+    count = r.get('count')
+
+    # If 'count' is None (not set in Redis), initialize it to 0
+    if count is None:
+        count = 0
+        r.set('count', count)
+
+    # Return a JSON response with the current count as an integer
+    return {'count': int(count)}
+
+# Run the Flask app if this script is the main entry point, e.g. using app.run()
+# but if app is being served by other means, e.g. by Gunicorn etc., let them set the binding
+if __name__ == "__main__":
+    # Set the host to '0.0.0.0' to make the app accessible outside the container (e.g. by Nginx)
+    # Use the port specified by the 'PORT' environment variable, defaulting to 8080
+    app.run(host="0.0.0.0", port=int(os.getenv("PORT", 8080)))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3' 
+
+# Define the services that will be managed by Docker Compose
+services:  
+
+  redis:
+    image: redis:7.2.1  
+    volumes:
+      - ./redis/redis.conf:/usr/local/etc/redis/redis.conf  # Mount the local 'redis.conf' file to the configuration file location in the container
+      - redis-data:/data  # Mount a named volume for Redis data
+    command: redis-server /usr/local/etc/redis/redis.conf  # Start the Redis server with the custom configuration file
+    networks:
+      - counter-network # Use the network defined below
+
+  nginx:
+    image: nginx:1.25.2 
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf  # Mount the local 'nginx.conf' file to the configuration file location in the container
+    ports:
+      - "80:80"
+    depends_on:
+      - counter-service
+    networks:
+      - counter-network # Use the network defined below
+
+  counter-service:
+    image: ghcr.io/mmayzlesh/counter-service:latest  # Uss the latest image by default. Specific tag can be set to use previous versions
+    expose:
+      - "8080"
+    depends_on:
+      - redis
+    networks:
+      - counter-network # Use the network defined below
+
+networks:  # Define network to be created and used by all the services
+  counter-network:
+    driver: bridge  # Use the default bridge network driver
+
+volumes: # Define named volumes
+  redis-data:  # Named volume for storing Redis data

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,34 @@
+# Nginx configurration file
+
+# Set the number of worker processes to 1 (usually adjusted based on system resources)
+worker_processes 1;
+
+# Configure event handling, such as the maximum number of connections per worker
+events {
+    worker_connections 1024;
+}
+
+# Define HTTP server settings
+http {
+    # Define an upstream block named 'app' for proxying requests to the application
+    upstream app {
+        server counter-service:8080;  # Specify the address of the backend application
+    }
+
+    # Configure an HTTP server block that listens on port 80
+    server {
+        listen 80;
+
+        # Define location-based rules for handling requests
+        location / {
+            # Proxy incoming requests to the 'app' upstream block
+            proxy_pass http://app;
+            
+            # Set HTTP headers for proxying
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}

--- a/redis/redis.conf
+++ b/redis/redis.conf
@@ -1,0 +1,9 @@
+# Redis Configuration File
+
+# This directive enables the Append-Only File (AOF) mode in Redis.
+# AOF mode is a persistence mechanism in Redis that logs every write operation
+# received by the server, thereby providing durability and the ability to
+# reconstruct the dataset in the event of a crash or data loss.
+# See: https://redis.io/docs/management/persistence/
+
+appendonly yes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask==3.0.0
+gunicorn==21.2.0
+redis==5.0.0


### PR DESCRIPTION
This PR will merge full functionality of the counter-service system into main branch, thus allowing deployment into the remote VM.

Details about the system and its architecture appear in the README file.
In general:
- GitHub actions manages the CI/CD process
- Main system is a Python Flask app, served with Gunicorn in Docker
- Redis stores the values in a persisted manner, with custom configuration
- Nginx serves as a reverse proxy to serve the system externally, with custom configuration, to allow better control on the serving process.
- Docker compose orchestrate all the services.

Only builds to main branch deploy the system on the target VM.
Builds on non-main branches just create a Docker image and store in in GHCR.

The URL to access the system after successful deployment is:
[http://ec2-18-192-42-86.eu-central-1.compute.amazonaws.com](http://ec2-18-192-42-86.eu-central-1.compute.amazonaws.com/)